### PR TITLE
feat: adds helmet to express

### DIFF
--- a/nx-ssr/README.md
+++ b/nx-ssr/README.md
@@ -1,11 +1,21 @@
-# NX-SSR 
+# NX-SSR
 
 Angular 17 Universal Server Side Rendering with Nx
+
+## Engine
+
+- node 20.9.x
+- npm 8.1.x
+- Angular 17
+- Nx 13.0.x
+- Nestjs 9.0.x
 
 ## Infrastructure
 
 - Angular 17 SSR with express
-- Nginx as reverse proxy with static file server
+- Nginx as reverse proxy
+- Nginx serve static files from angular browser folder
+- Nestjs for API (mock data)
 
 ## Based on NX Workspace
 

--- a/nx-ssr/package-lock.json
+++ b/nx-ssr/package-lock.json
@@ -22,6 +22,7 @@
         "@nx/angular": "18.3.4",
         "express": "~4.19.2",
         "express-rate-limit": "^7.2.0",
+        "helmet": "^7.1.0",
         "rxjs": "~7.8.1",
         "serve-favicon": "^2.5.0",
         "tslib": "^2.6.2",
@@ -11737,6 +11738,14 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/nx-ssr/package.json
+++ b/nx-ssr/package.json
@@ -22,6 +22,7 @@
     "@nx/angular": "18.3.4",
     "express": "~4.19.2",
     "express-rate-limit": "^7.2.0",
+    "helmet": "^7.1.0",
     "rxjs": "~7.8.1",
     "serve-favicon": "^2.5.0",
     "tslib": "^2.6.2",
@@ -75,4 +76,3 @@
     "includedScripts": []
   }
 }
-

--- a/nx-ssr/src/middleware/index.ts
+++ b/nx-ssr/src/middleware/index.ts
@@ -1,1 +1,2 @@
 export * from './error.middleware';
+export * from './security.middleware';

--- a/nx-ssr/src/middleware/security.middleware.ts
+++ b/nx-ssr/src/middleware/security.middleware.ts
@@ -1,0 +1,13 @@
+import type { Application } from 'express';
+import helmet from 'helmet';
+
+export function useSecurityMiddleware(app: Application): void {
+  // Remove fingerprinting
+  app.disable('x-powered-by');
+
+  // Default secure response header. For details, see https://helmetjs.github.io/
+  app.use(helmet());
+
+  // App behind a reverse proxy
+  app.set('trust proxy', 'loopback');
+}


### PR DESCRIPTION
Some optimisations made to the Express app:

- helmet as security middleware
- support for the app behind a reverse proxy
- type-coverage for SIGTERM `express.close()`